### PR TITLE
More flexible version handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 version/version.go
+tags
+*.swp
+

--- a/api/api.go
+++ b/api/api.go
@@ -11,16 +11,17 @@ import (
 	"github.com/harbourmaster/hbm/pkg/utils"
 )
 
-var SupportedVersion = "v1.23"
+var DefaultVersion = "v1.23"
+var SupportedVersions = []string{"v1.23", "v1.24"}
 
 type Api struct {
-	Uris	*uri.URIs
-	AppPath	string
+	Uris    *uri.URIs
+	AppPath string
 }
 
 func NewApi(version, appPath string) (*Api, error) {
-	if version != SupportedVersion {
-		return &Api{}, fmt.Errorf("This version of HBM does not support Docker API version %s. Supported version is %s", version, SupportedVersion)
+	if !utils.StringInSlice(SupportedVersions, version) {
+		return &Api{}, fmt.Errorf("This version of HBM does not support Docker API version %s. Supported versions are %s", version, SupportedVersions)
 	}
 
 	uris := uri.New()
@@ -110,7 +111,7 @@ func (a *Api) Allow(req authorization.Request) *types.AllowResult {
 				r := &types.AllowResult{Allow: true}
 
 				// Validate Docker command is allowed
-				if ! d.KeyExists("action", u.Action) {
+				if !d.KeyExists("action", u.Action) {
 					r = &types.AllowResult{Allow: false, Error: fmt.Sprintf("%s is not allowed", u.CmdName)}
 				}
 				d.Conn.Close()
@@ -122,9 +123,9 @@ func (a *Api) Allow(req authorization.Request) *types.AllowResult {
 				}
 
 				// If Docker command is not allowed, return
-                                if ! r.Allow {
-                                        return r
-                                }
+				if !r.Allow {
+					return r
+				}
 			}
 		}
 	}

--- a/cmd/action.go
+++ b/cmd/action.go
@@ -6,55 +6,55 @@ import (
 
 	"github.com/harbourmaster/hbm/api"
 	"github.com/harbourmaster/hbm/pkg/db"
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 var actionCmd = &cobra.Command{
-        Use:    "action",
-        Short:  "Manage whitelisted actions",
-        Long:	"Manage whitelisted actions",
+	Use:   "action",
+	Short: "Manage whitelisted actions",
+	Long:  "Manage whitelisted actions",
 }
 
 var actionListOptionsCmd = &cobra.Command{
-        Use:    "options",
-        Short:  "List options actions",
-        Long:	"List options actions",
+	Use:   "options",
+	Short: "List options actions",
+	Long:  "List options actions",
 }
 
 var actionListCmd = &cobra.Command{
-        Use:    "ls",
-        Short:  "List whitelisted actions",
-        Long:	"List whitelisted actions",
+	Use:   "ls",
+	Short: "List whitelisted actions",
+	Long:  "List whitelisted actions",
 }
 
 var actionAddCmd = &cobra.Command{
-        Use:    "add",
-        Short:  "Add action to the whitelist",
-        Long:	"Add action to the whitelist",
+	Use:   "add",
+	Short: "Add action to the whitelist",
+	Long:  "Add action to the whitelist",
 }
 
 var actionRemoveCmd = &cobra.Command{
-        Use:    "rm",
-        Short:  "Remove action from the whitelist",
-        Long:	"Remove action from the whitelist",
+	Use:   "rm",
+	Short: "Remove action from the whitelist",
+	Long:  "Remove action from the whitelist",
 }
 
 func init() {
-        RootCmd.AddCommand(actionCmd)
+	RootCmd.AddCommand(actionCmd)
 	actionCmd.AddCommand(actionListOptionsCmd)
 	actionCmd.AddCommand(actionListCmd)
 	actionCmd.AddCommand(actionAddCmd)
 	actionCmd.AddCommand(actionRemoveCmd)
 
-        actionCmd.Run = actionList
-        actionListOptionsCmd.Run = actionListOptions
-        actionListCmd.Run = actionList
-        actionAddCmd.Run = actionAdd
-        actionRemoveCmd.Run = actionRemove
+	actionCmd.Run = actionList
+	actionListOptionsCmd.Run = actionListOptions
+	actionListCmd.Run = actionList
+	actionAddCmd.Run = actionAdd
+	actionRemoveCmd.Run = actionRemove
 }
 
 func actionListOptions(cmd *cobra.Command, args []string) {
-	data, _ := api.NewApi(api.SupportedVersion, "")
+	data, _ := api.NewApi(api.DefaultVersion, "")
 
 	fmt.Printf("%-25s | %-20s | %s\n", "Action", "Command Name", "Description")
 	fmt.Println("-----------------------------------------------------------------------------------------------------------------------")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,9 +3,16 @@ package utils
 import (
 	"os"
 	"regexp"
+	"sort"
 
 	"github.com/docker/go-plugins-helpers/authorization"
 )
+
+func StringInSlice(haystack []string, needle string) bool {
+	s := sort.StringSlice(haystack)
+	s.Sort()
+	return s.Search(needle) < len(haystack)
+}
 
 func GetURIInfo(req authorization.Request) (string, string) {
 	reURI := regexp.MustCompile(`^/(v[0-9]+\.[0-9]+)(/.*)`)


### PR DESCRIPTION
I guess my vim go plugin mangles whitespace...

This way we can have multiple "supported" versions of the docker api.

Right now they are treated as compatible, but this is a base to build upon.